### PR TITLE
[Merged by Bors] - chore(bors): do not build master, enable squashing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches:
-    - master
     - staging
     - trying
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,8 @@
 status = [ "build all%" ]
 block_labels = [ "S-wip", "S-nomerge" ]
+pr_status = [ "DCO" ]
 
+use_squash_merge = true
 delete_merged_branches = true
 timeout_sec = 7200 # two hours
 


### PR DESCRIPTION
Because bors now controls the merge process, it will always run a build
on `staging` before fast-forwarding `master` to that point, meaning the
commit that is pushed will already have a green build light on it.
Adding 'master' just means the build will get run twice for a single
commit, which could get expensive.

This also enables squashing and DCO compliance.