### PR TITLE
Touchups, rename plugin, semantic commits

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,19 @@
+commitsOnly: true
+allowMergeCommits: false
+anyCommit: false
+
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+
+# scopes:
+#   - ...

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PLUGIN=bluespec
 YOSYS_CONFIG?=yosys-config
 
 CXX=$(shell $(YOSYS_CONFIG) --cxx)
@@ -7,9 +8,9 @@ LDLIBS=$(shell $(YOSYS_CONFIG) --ldlibs)
 
 PREFIX?=$(shell $(YOSYS_CONFIG) --datdir)/plugins
 
-SRC=bsv.cc
-OBJ=bsv.o
-SO=bsv.so
+SRC=$(PLUGIN).cc
+OBJ=$(PLUGIN).o
+SO=$(PLUGIN).so
 
 FINALDEST=$(DESTDIR)$(PREFIX)
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ ingests the results.
 [Yosys]: https://github.com/yosyshq/yosys
 [Bluespec]: https://github.com/B-Lang-org/bsc
 
----
-
 ## Installation
 
 Just run `make install`. The `Makefile` will use `yosys-config` to determine
@@ -44,16 +42,12 @@ If Yosys is installed globally, you'll need to use `sudo` with the `install`
 target. The `install` target supports `PREFIX=` and `DESTDIR=` so you can
 control the installation paths as you expect.
 
----
-
 ## Usage
 
-Run `plugin -i bsv` once you've dropped inside `yosys`. This gives you the
-`bsv` command.
+Run `plugin -i bluespec` once you've dropped inside `yosys`. This gives you the
+`read_bluespec` command.
 
-Run `help bsv` inside Yosys for detailed information.
-
----
+Run `help read_bluespec` inside Yosys for detailed information.
 
 ## Quick Example
 
@@ -61,39 +55,40 @@ Given you have some BlueSpec package `Foo.bsv`, with a top-level module you
 want to synthesize called `mkFoo`, you can spit out a "prepped" Verilog file as
 follows (using escaped strings in Bash):
 
-```lang=bash
+```bash
 $ yosys -p "\
-plugin -i bsv;
-bsv -top mkFoo Foo.bsv;
+plugin -i bluespec;
+read_bluespec -top mkFoo Foo.bsv;
 prep;
 write_verilog -attr2comment out.v;
 "
 ```
 
-The resulting `out.v` file will contain your prepped Verilog output. This file
-is standalone and does not depend on BSV or BSV Verilog primitives at all, and
+> **NOTE**: The `read_bluespec` command only supports the SystemVerilog flavor
+> of Bluespec. Haskell support will be added in the future.
+
+The resulting `out.v` file will contain your Verilog output. This file is
+standalone and does not depend on BSV or BSV Verilog primitives at all, and
 should work in a verification/synthesis toolchain.
 
 The compiled `Foo.bsv` module will have all of its dependencies automatically
 compiled as well. All BlueSpec modules that have been marked `(* synthesize *)`
 to emit Verilog output will be incorporated into the resulting Verilog design.
 
-The `bsv` command always completely recompiles its input files, so it may not
-be appropriate for fast development iteration, only for true synthesis runs
-through your toolchain.
+The `read_bluespec` command always fully recompiles its input files, so it may
+not be appropriate for fast development iteration, only for true
+synthesis/integration runs through your toolchain.
 
-> **NOTE**: the `bsv` plugin attempts to automatically resolves modules for BSV
-> primitives written in Verilog. For example, using the `FIFO::*` package in
-> BSV and compiling to Verilog results in a module that depends on `FIFO2.v`,
-> located in `$BLUESPECDIR/Verilog/FIFO2.v`. This module will be loaded
-> automatically.
->
-> This feature is on by default, which makes it relatively easy to incorporate
-> custom BlueSpec designs into Yosys quickly. See `help bsv` for more
-> information on this feature and how to turn it off for more advanced use
-> cases.
+## Module resolution
 
----
+The `bluespec` plugin attempts to automatically resolves modules for BSV
+primitives written in Verilog. For example, using the `FIFO::*` package in BSV
+and compiling to Verilog results in a module that depends on `FIFO2.v`, located
+in `$BLUESPECDIR/Verilog/FIFO2.v`. This module will be loaded automatically.
+
+This feature is on by default, which makes it relatively easy to incorporate
+custom BlueSpec designs into Yosys quickly. See `help read_bluespec` for more
+information on this feature and how to turn it off for more advanced use cases.
 
 ## Future work
 
@@ -103,8 +98,6 @@ with FOSS EDA tools. Please feel free to submit ideas or improvements.
 
 Now that Bluespec is open source, future work might revolve around improved
 integration with `bluetcl` or somesuch.
-
----
 
 ## License
 

--- a/bluespec.cc
+++ b/bluespec.cc
@@ -1,5 +1,5 @@
 /*
-** bsv.cc -- a convenient BlueSpec Verilog synthesis plugin for Yosys.
+** bluespec.cc -- a BlueSpec Verilog frontend plugin for Yosys.
 ** Copyright (C) 2017 Austin Seipp. See Copyright Notice in LICENSE.txt
 */
 #include "kernel/yosys.h"
@@ -108,11 +108,11 @@ void expand_bsv_libs(RTLIL::Design *design, RTLIL::Module *module) {
 }
 
 struct BsvFrontend : public Pass {
-  BsvFrontend() : Pass("bsv", "load BlueSpec Verilog designs using bsc") {}
+  BsvFrontend() : Pass("read_bluespec", "compile and load Bluespec modules") {}
   virtual void help()
   {
     log("\n");
-    log("    bsv [options] <bsv-file>\n");
+    log("    read_bluespec [options] <bsv-file>\n");
     log("\n");
     log("This command reads the given BlueSpec Verilog file, compiles\n");
     log("them using the 'bsc' compiler, and then reads the Verilog using\n");

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [ "build all%" ]
 block_labels = [ "S-wip", "S-nomerge" ]
-pr_status = [ "DCO" ]
+pr_status = [ "DCO", "Semantic Pull Request" ]
 
 delete_merged_branches = true
 timeout_sec = 7200 # two hours

--- a/default.nix
+++ b/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation {
   src = lib.cleanSource ./.;
 
   buildInputs = [ yosys readline zlib ];
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig bluespec ];
 
-  doCheck = false; # [NOTE]: nixpkgs pr #79468
+  doCheck = true;
   makeFlags = [ "PREFIX=$(out)/share/yosys/plugins" ];
 }

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,5 +1,5 @@
 {
-  "url":    "https://github.com/nixos/nixpkgs-channels/archive/0c960262d159d3a884dadc3d4e4b131557dad116.tar.gz",
-  "rev":    "0c960262d159d3a884dadc3d4e4b131557dad116",
-  "sha256": "0d7ms4dxbxvd6f8zrgymr6njvka54fppph1mrjjlcan7y0dhi5rb"
+  "url":    "https://github.com/nixos/nixpkgs-channels/archive/ca3531850844e185d483fb878fcd00c6b44069e5.tar.gz",
+  "rev":    "ca3531850844e185d483fb878fcd00c6b44069e5",
+  "sha256": "1s1zhzdbmdd7l936g7ydzsjqdi5k5ch6vpjilil0jiwjhrpkw3m4"
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -12,6 +12,11 @@ REPO=${REPO:-"nixpkgs-channels"}
 BRANCH=${BRANCH:-"nixpkgs-unstable"}
 URL="https://github.com/${ORG}/${REPO}"
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+[ ! -e "$SCRIPT_DIR/nixpkgs.json" ] && \
+  >&2 echo "ERROR: nixpkgs.json must be located next to this update script!" && \
+  exit 1
+
 if [[ "x$1" == "x" ]]; then
   echo -n "No revision, so grabbing latest upstream Nixpkgs master commit... "
   REV=$(curl -s "${API}/nixos/${REPO}/commits/${BRANCH}" | jq -r '.sha')
@@ -31,7 +36,7 @@ DOWNLOAD="$URL/archive/$REV.tar.gz"
 echo "Updating to nixpkgs revision ${REV:0:6} from $URL"
 SHA256=$(nix-prefetch-url --unpack "$DOWNLOAD")
 
-cat > $(git rev-parse --show-toplevel)/nix/nixpkgs.json <<EOF
+cat > "$SCRIPT_DIR/nixpkgs.json" <<EOF
 {
   "url":    "$DOWNLOAD",
   "rev":    "$REV",

--- a/t/test.yosys
+++ b/t/test.yosys
@@ -1,4 +1,4 @@
-plugin -i bsv.so
-bsv -top mkTest t/GCD.bsv
+plugin -i bluespec.so
+read_bluespec -top mkTest t/GCD.bsv
 prep
 write_verilog -attr2comment t/GCD.v


### PR DESCRIPTION
Bluespec supports both the SystemVerilog and Haskell dialects, so the `bsv` shorthand is something of a misnomer. Instead, we'll use `bluespec` instead where appropriate. The plugin is now also appropriately called `read_bluespec` to make it look more like a proper frontend.

The bluespec compiler correctly distinguishes `.bs` (Haskell) and `.bsv` (SystemVerilog) files for us, so I don't think we need to handle that distinction in the frontend at all, and we can just assume the user passes a correct file.

This also experiments with enabling [semantic commit messages](https://github.com/zeke/semantic-pull-requests).