### PR TITLE
Various UX improvements

### DIFF
--- a/bluespec.cc
+++ b/bluespec.cc
@@ -180,13 +180,14 @@ struct BsvFrontend : public Pass {
       log("            '%s/Verilog'\n",s);
     } else {
       log("        WARNING: BLUESPECDIR is not set! This might mean that\n");
-      log("        BlueSpec isn't installed, or is installed incorrectly.\n");
+      log("        Bluespec isn't installed, or is installed incorrectly.\n");
       log("        This plugin will not work as a result, failing with a\n");
       log("        really huge and cool explosion sound when you use it.\n");
     }
 
     log("\n");
-    log("        The value of this flag is false by default.\n");
+    log("        The value of this flag is false by default: compiled Bluespec\n");
+    log("        modules will have Verilog primitives loaded automatically.\n");
     log("\n");
     log("The following options are passed as-is to bsc:\n");
     log("\n");
@@ -196,12 +197,9 @@ struct BsvFrontend : public Pass {
     log("    -show-schedule\n");
     log("    -show-stats\n");
     log("\n");
-    log("By default, the BlueSpec compiler 'bsc' is invoked out of $PATH,\n");
+    log("By default, the Bluespec compiler 'bsc' is invoked out of $PATH,\n");
     log("but you may specify the BSC_PATH environment variable to specify\n");
     log("the exact location of the compiler.\n");
-    log("\n");
-    log("Visit http://www.bluespec.com and contact BlueSpec, Inc. for more\n");
-    log("information on BlueSpec Verilog.\n");
     log("\n");
   }
 
@@ -215,12 +213,12 @@ struct BsvFrontend : public Pass {
 
     if (get_bluespecdir() == "")
       log_cmd_error("The BLUESPECDIR environment variable isn't defined.\n"
-                    "This indicates BlueSpec might not be installed or\n"
+                    "This indicates Bluespec might not be installed or\n"
                     "not installed correctly. BLUESPECDIR is needed\n"
                     "to locate Verilog primitives correctly. Exiting\n"
                     "without performing synthesis.\n");
 
-    log_header(design, "Executing the BlueSpec compiler (with '%s').\n",
+    log_header(design, "Executing the Bluespec compiler (with '%s').\n",
                compiler.c_str());
     log_push();
 
@@ -266,14 +264,13 @@ struct BsvFrontend : public Pass {
       log_cmd_error("Missing -top option.\n");
 
     top_package = args[argidx];
-    log_header(design, "Compiling BlueSpec module %s:%s to Verilog.\n",
-               top_package.c_str(), top_entity.c_str());
+    log_header(design, "Compiling Bluespec package %s\n", top_package.c_str());
 
     // Run the Bluespec compiler
     std::string temp_vdir = make_temp_dir("/tmp/yosys-bsv-v-XXXXXX");
     std::string temp_odir = make_temp_dir("/tmp/yosys-bsv-o-XXXXXX");
 
-    log("Compiling BlueSpec objects/verilog to %s:%s\n",
+    log("Compiling Bluespec objects/verilog to %s:%s\n",
         temp_odir.c_str(), temp_vdir.c_str());
 
     std::string command = "exec 2>&1; ";
@@ -295,7 +292,7 @@ struct BsvFrontend : public Pass {
                 command.c_str(), ret);
 
     // Read all of the Verilog output
-    log_header(design, "Reading BlueSpec Verilog output.\n");
+    log_header(design, "Reading Bluespec compiler output.\n");
 
     auto files = glob_filename(temp_vdir + "/*.v");
     for (const auto& f : files) {

--- a/bluespec.cc
+++ b/bluespec.cc
@@ -139,7 +139,10 @@ struct BsvFrontend : public Pass {
     log("\n");
 
     log("    -top <top-entity-name>\n");
-    log("        The name of the top entity. This option is mandatory.\n");
+    log("        By default, the frontend loads all individual modules marked with\n");
+    log("        'synthesize' attributes. If none exist, or you wish to only use\n");
+    log("        one particular module, this option can be used to select a single\n");
+    log("        Bluespec module to compile\n");
     log("\n");
 
     log("    -no-autoload-bsv-prims\n");
@@ -244,8 +247,6 @@ struct BsvFrontend : public Pass {
 
     if (argidx == args.size())
       cmd_error(args, argidx, "Missing filename for top-level module.");
-    if (top_entity.empty())
-      log_cmd_error("Missing -top option.\n");
 
     top_package = args[argidx];
     log_header(design, "Compiling Bluespec package %s\n", top_package.c_str());
@@ -266,7 +267,8 @@ struct BsvFrontend : public Pass {
       command = command + " " + a;
 
     command += stringf(" -verilog");
-    command += stringf(" -g '%s'", top_entity.c_str());
+    if (!top_entity.empty())
+      command += stringf(" -g '%s'", top_entity.c_str());
     command += stringf(" -u '%s'", top_package.c_str());
 
     log("Running \"%s\"...\n", command.c_str());

--- a/bluespec.cc
+++ b/bluespec.cc
@@ -1,5 +1,5 @@
 /*
-** bluespec.cc -- a BlueSpec Verilog frontend plugin for Yosys.
+** bluespec.cc -- a Bluespec frontend for Yosys
 ** Copyright (C) 2017 Austin Seipp. See Copyright Notice in LICENSE.txt
 */
 #include "kernel/yosys.h"
@@ -7,9 +7,14 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
+void read_verilog(RTLIL::Design *design, std::istream *ff, std::string f)
+{
+  Frontend::frontend_call(design, ff, f, "verilog");
+}
+
 /*
 ** Retrieve the value of the BSC_PATH environment variable. If not set,
-** return the default "bsc" command for invoking the BlueSpec compiler.
+** return the default "bsc" command for invoking the Bluespec compiler.
 */
 std::string get_compiler(void)
 {
@@ -46,7 +51,7 @@ std::string get_bluespecdir(void)
 }
 
 /*
-** Expand unresolved BlueSpec Verilog primitives to their Verilog counterparts
+** Expand unresolved Bluespec Verilog primitives to their Verilog counterparts
 ** under $BLUESPECDIR.
 **
 ** This code is based off the 'hierarchy' pass, and ideally, we'd use hierarchy
@@ -76,14 +81,14 @@ void expand_bsv_libs(RTLIL::Design *design, RTLIL::Module *module) {
       if (cell->type[0] == '$')
         continue;
 
-      // And try to find/load the BlueSpec primitive
+      // And try to find/load the Bluespec primitive
       auto unadorned = RTLIL::unescape_id(cell->type);
       auto filename  = bluespecdir + "/Verilog/" + unadorned + ".v";
       log("Looking for Verilog module '%s' in $BLUESPECDIR/Verilog/%s.v\n",
           unadorned.c_str(), unadorned.c_str());
 
       if (check_file_exists(filename)) {
-        Frontend::frontend_call(design, NULL, filename, "verilog");
+        read_verilog(design, NULL, filename);
         goto loaded;
       }
 
@@ -300,7 +305,7 @@ struct BsvFrontend : public Pass {
       if (ff.fail())
         log_error("Can't open bsc output file `%s'!\n", f.c_str());
 
-      Frontend::frontend_call(design, &ff, f, "verilog");
+      read_verilog(design, &ff, f);
     }
 
     // Read all of the BSV Verilog libraries, unless told otherwise


### PR DESCRIPTION
This improves the help output, and allows the user to configure reset sensitivity in the absorbed code using the new `-reset` flag to `read_bluespec`. By default, compiled Bluespec modules use negative reset: a value of `0` will put the device into reset state, which is equivalent to `-reset neg`.

Furthermore, the `-top` module is not actually mandatory by default. By default, the Bluespec compiler will emit a single `.v` file for each single `synthesize` attribute, it doesn't need to be guided. This was the only reason we used the top parameter.

The behavior of `read_bluespec` is now to  read *all* modules which are marked as synthesizable, which is probably much closer to the desired user expectation. Users are free to use other synthesis passes in order to specify the top module (e.g. `synth -top ...`) for further use. Instead, `-top` is only needed if you want to *not* mark something with synthesis, or you only want to compile *exactly* one module, for whatever reason.