### PR TITLE
Optionally embed path to bsc compiler at build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     name: build all
     timeout-minutes: 360
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v6
+      uses: cachix/install-nix-action@v12
 
     - name: nix-build (for ${{ matrix.nixpkgs }})
       env:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ SO=$(PLUGIN).so
 
 FINALDEST=$(DESTDIR)$(PREFIX)
 
+ifneq ($(STATIC_BSC_PATH),)
+CXXFLAGS+=-DSTATIC_BSC_PATH=\"$(STATIC_BSC_PATH)\"
+endif
+
+ifneq ($(STATIC_BSC_LIBDIR),)
+CXXFLAGS+=-DSTATIC_BSC_LIBDIR=\"$(STATIC_BSC_LIBDIR)\"
+endif
+
 $(SO): $(OBJ)
 	$(CXX) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 $(OBJ): $(SRC)

--- a/bluespec.cc
+++ b/bluespec.cc
@@ -21,12 +21,16 @@ void read_verilog(RTLIL::Design *design, std::istream *ff, std::string f, std::s
 */
 std::string get_compiler(void)
 {
+#ifdef STATIC_BSC_PATH
+  return STATIC_BSC_PATH;
+#else
   char* e = getenv("BSC_PATH");
 
   if (e == nullptr)
     return "bsc";
   else
     return std::string(e);
+#endif
 }
 
 /*
@@ -35,6 +39,9 @@ std::string get_compiler(void)
 */
 std::string get_bluespecdir(void)
 {
+#ifdef STATIC_BSC_LIBDIR
+  return STATIC_BSC_LIBDIR;
+#else
   // [FIXME] (aseipp): we currently just pull `bluectl` out of the environment
   // without allowing an override (cf BSC_PATH). ideally we should fix bsc to
   // give us this path directly anyway
@@ -51,6 +58,7 @@ std::string get_bluespecdir(void)
   }
 
   return libdir;
+#endif
 }
 
 /*

--- a/default.nix
+++ b/default.nix
@@ -15,14 +15,19 @@ let
 in
   
 with bootstrap.pkgs;
+
 stdenv.mkDerivation {
   pname = "yosys-bluespec";
   inherit (bootstrap) version;
   src = lib.cleanSource ./.;
 
-  buildInputs = [ yosys readline zlib ];
-  nativeBuildInputs = [ pkgconfig bluespec ];
+  buildInputs = [ yosys readline zlib bluespec ];
+  nativeBuildInputs = [ pkgconfig ];
 
   doCheck = true;
-  makeFlags = [ "PREFIX=$(out)/share/yosys/plugins" ];
+  makeFlags = [
+    "PREFIX=$(out)/share/yosys/plugins"
+    "STATIC_BSC_PATH=${bluespec}/bin/bsc"
+    "STATIC_BSC_LIBDIR=${bluespec}/lib"
+  ];
 }

--- a/nix/bootstrap.nix
+++ b/nix/bootstrap.nix
@@ -82,7 +82,7 @@ let
     let
       files = builtins.filter (f:
         let ext = builtins.substring (builtins.stringLength f - 4) 4 f;
-        in ext == ".nix"
+        in (builtins.stringLength f > 4) && ext == ".nix"
       ) (builtins.attrNames (builtins.readDir ./overlays));
     in builtins.map (x: import (./. + "/overlays/${x}")) files;
 
@@ -91,7 +91,7 @@ let
   versionInfo = pkgs.lib.splitString "\n" (pkgs.lib.fileContents versionFile);
   basever = builtins.elemAt versionInfo 0;
   vsuffix = pkgs.lib.optionalString (!officialRelease)
-    "+${toString repo.revCount}-g${repo.shortRev}";
+    "+${toString repo.revCount}r${repo.shortRev}";
 
   relname = builtins.elemAt versionInfo 1;
   version = "${basever}${vsuffix}";

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,5 +1,5 @@
 {
-  "url":    "https://github.com/nixos/nixpkgs-channels/archive/ca3531850844e185d483fb878fcd00c6b44069e5.tar.gz",
-  "rev":    "ca3531850844e185d483fb878fcd00c6b44069e5",
-  "sha256": "1s1zhzdbmdd7l936g7ydzsjqdi5k5ch6vpjilil0jiwjhrpkw3m4"
+  "url":    "https://github.com/nixos/nixpkgs/archive/2080afd039999a58d60596d04cefb32ef5fcc2a2.tar.gz",
+  "rev":    "2080afd039999a58d60596d04cefb32ef5fcc2a2",
+  "sha256": "0i677swvj8fxfwg3jibd0xl33rn0rq0adnniim8jnp384whnh8ry"
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -8,7 +8,7 @@ set -e
 
 API="https://api.github.com/repos"
 ORG=${ORG:-"nixos"}
-REPO=${REPO:-"nixpkgs-channels"}
+REPO=${REPO:-"nixpkgs"}
 BRANCH=${BRANCH:-"nixpkgs-unstable"}
 URL="https://github.com/${ORG}/${REPO}"
 
@@ -18,7 +18,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   exit 1
 
 if [[ "x$1" == "x" ]]; then
-  echo -n "No revision, so grabbing latest upstream Nixpkgs master commit... "
+  echo -n "No explicit revision given, so using latest commit from '${ORG}/${REPO}@${BRANCH}' ... "
   REV=$(curl -s "${API}/nixos/${REPO}/commits/${BRANCH}" | jq -r '.sha')
   echo "OK, got ${REV:0:6}"
 else


### PR DESCRIPTION
This is useful for e.g. Nix builds, where we want to fix the version used at build time. (Also helps avoid the flaw mentioned in the `FIXME` in `get_bluespecdir`, coincidentally.)